### PR TITLE
raspberrypi5-64.conf: set ARMSTUB

### DIFF
--- a/conf/machine/raspberrypi5-64.conf
+++ b/conf/machine/raspberrypi5-64.conf
@@ -33,4 +33,4 @@ KERNEL_IMAGETYPE_UBOOT ?= "Image"
 KERNEL_IMAGETYPE_DIRECT ?= "Image"
 KERNEL_BOOTCMD ?= "booti"
 
-ARMSTUB ?= "armstub8-gic.bin"
+ARMSTUB ?= "armstub8-2712.bin"


### PR DESCRIPTION
Set ARMSTUB for raspberrypi5-64 to armstub8-2712.bin.

This work was sponsored by GOVCERT.LU.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
