### PR TITLE
Raspberry Pi 5 Minor Fixes

### DIFF
--- a/.github/workflows/yocto-builds.yml
+++ b/.github/workflows/yocto-builds.yml
@@ -25,6 +25,8 @@ jobs:
           - raspberrypi3
           - raspberrypi4-64
           - raspberrypi4
+          - raspberrypi5-64
+          - raspberrypi5
           - raspberrypi-cm3
           - raspberrypi-cm
           - raspberrypi-armv7

--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -54,6 +54,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/vc4-fkms-v3d-pi4.dtbo \
     overlays/vc4-kms-v3d.dtbo \
     overlays/vc4-kms-v3d-pi4.dtbo \
+    overlays/vc4-kms-v3d-pi5.dtbo \
     overlays/vc4-kms-dsi-7inch.dtbo \
     overlays/w1-gpio.dtbo \
     overlays/w1-gpio-pullup.dtbo \

--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -77,6 +77,7 @@ RPI_KERNEL_DEVICETREE ?= " \
     bcm2710-rpi-cm3.dtb \
     bcm2711-rpi-cm4.dtb \
     bcm2711-rpi-cm4s.dtb \
+    bcm2712-rpi-5-b.dtb \
     "
 
 KERNEL_DEVICETREE ??= " \

--- a/conf/machine/raspberrypi-armv8.conf
+++ b/conf/machine/raspberrypi-armv8.conf
@@ -32,6 +32,7 @@ RPI_KERNEL_DEVICETREE = " \
     broadcom/bcm2711-rpi-400.dtb \
     broadcom/bcm2711-rpi-cm4.dtb \
     broadcom/bcm2711-rpi-cm4s.dtb \
+    broadcom/bcm2712-rpi-5-b.dtb \
 "
 
 SDIMG_KERNELIMAGE ?= "kernel8.img"

--- a/conf/machine/raspberrypi5-64.conf
+++ b/conf/machine/raspberrypi5-64.conf
@@ -1,0 +1,36 @@
+#@TYPE: Machine
+#@NAME: RaspberryPi 5 Development Board (64bit)
+#@DESCRIPTION: Machine configuration for the RaspberryPi 5 in 64 bits mode
+
+MACHINEOVERRIDES =. "raspberrypi5:"
+
+MACHINE_FEATURES += "pci"
+MACHINE_EXTRA_RRECOMMENDS += "\
+    linux-firmware-rpidistro-bcm43455 \
+    bluez-firmware-rpidistro-bcm4345c0-hcd \
+    linux-firmware-rpidistro-bcm43456 \
+    bluez-firmware-rpidistro-bcm4345c5-hcd \
+"
+
+require conf/machine/include/arm/armv8-2a/tune-cortexa76.inc
+include conf/machine/include/rpi-base.inc
+
+RPI_KERNEL_DEVICETREE = " \
+    broadcom/bcm2712-rpi-5-b.dtb \
+"
+
+SDIMG_KERNELIMAGE ?= "kernel8.img"
+SERIAL_CONSOLES ?= "115200;ttyS0"
+
+UBOOT_MACHINE = "rpi_arm64_config"
+
+VC4DTBO ?= "vc4-kms-v3d"
+
+# When u-boot is enabled we need to use the "Image" format and the "booti"
+# command to load the kernel
+KERNEL_IMAGETYPE_UBOOT ?= "Image"
+# "zImage" not supported on arm64 and ".gz" images not supported by bootloader yet
+KERNEL_IMAGETYPE_DIRECT ?= "Image"
+KERNEL_BOOTCMD ?= "booti"
+
+ARMSTUB ?= "armstub8-gic.bin"

--- a/conf/machine/raspberrypi5.conf
+++ b/conf/machine/raspberrypi5.conf
@@ -1,0 +1,23 @@
+#@TYPE: Machine
+#@NAME: RaspberryPi 5 Development Board (32bit)
+#@DESCRIPTION: Machine configuration for the RaspberryPi 5 in 32 bit mode
+
+DEFAULTTUNE ?= "cortexa7thf-neon-vfpv4"
+require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+include conf/machine/include/rpi-base.inc
+
+MACHINE_FEATURES += "pci"
+MACHINE_EXTRA_RRECOMMENDS += "\
+    linux-firmware-rpidistro-bcm43455 \
+    bluez-firmware-rpidistro-bcm4345c0-hcd \
+    linux-firmware-rpidistro-bcm43456 \
+    bluez-firmware-rpidistro-bcm4345c5-hcd \
+"
+
+# 'l' stands for LPAE
+SDIMG_KERNELIMAGE ?= "kernel7l.img"
+UBOOT_MACHINE = "rpi_4_32b_config"
+SERIAL_CONSOLES ?= "115200;ttyS0"
+
+VC4DTBO ?= "vc4-kms-v3d"
+ARMSTUB ?= "armstub7.bin"

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -316,6 +316,11 @@ do_deploy() {
         echo "# Enable One-Wire Interface" >> $CONFIG
         echo "dtoverlay=w1-gpio" >> $CONFIG
     fi
+
+    # Reduce config.txt file size to avoid corruption and
+    # to boot successfully Raspberry Pi 5
+    sed -i '/^##/d' $CONFIG
+
 }
 
 do_deploy:append:raspberrypi3-64() {

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -12,3 +12,7 @@ do_install:append:rpi () {
     install -d ${D}${sysconfdir}
     install -m 0644 ${WORKDIR}/fw_env.config ${D}${sysconfdir}/fw_env.config
 }
+
+# Temporary avoid Raspberry Pi 5 because U-Boot has not been ported yet
+COMPATIBLE_MACHINE:raspberrypi5-64 = "(-)"
+COMPATIBLE_MACHINE:raspberrypi5 = "(-)"

--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -33,6 +33,8 @@ KBUILD_DEFCONFIG:raspberrypi4 ?= "bcm2711_defconfig"
 KBUILD_DEFCONFIG:raspberrypi4-64 ?= "bcm2711_defconfig"
 KBUILD_DEFCONFIG:raspberrypi-armv7 ?= "bcm2711_defconfig"
 KBUILD_DEFCONFIG:raspberrypi-armv8 ?= "bcm2711_defconfig"
+KBUILD_DEFCONFIG:raspberrypi5 ?= "bcm2711_defconfig"
+KBUILD_DEFCONFIG:raspberrypi5-64 ?= "bcm2711_defconfig"
 
 LINUX_VERSION_EXTENSION ?= ""
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

* Added `overlays/vc4-kms-v3d-pi5.dtbo` to use `vc4-kms-v3d` driver on Raspberry Pi 5. Tested it for `raspberrypi5-64` and `core-image-weston`.
* `u-boot_%.bbappend`: temporary avoid Raspberry Pi 5 machines because U-Boot has not been ported to them yet.
* `rpi-config`: Removed some comments to reduce config.txt file size to avoid file corruption and make sure Raspberry Pi 5 will boot successfully.

**- How I did it**

Changes were tested on Raspberry Pi 5 with 4GB RAM with images core-image-minimal and core-image-weston for machine `raspberrypi5-64`.
